### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Weekly npm dependency updates, simplified from the [app-store-receipt-parser config](https://github.com/tamtamchik/app-store-receipt-parser/blob/main/.github/dependabot.yml):

- `weekly` (defaults to Monday) — explicit day/time/timezone dropped.
- `open-pull-requests-limit: 2` — keeps the queue short.
- `cooldown: 7 days` — never picks up a release younger than a week (supply-chain safety), single threshold instead of per-semver tiers.
- No `versioning-strategy: lockfile-only` — as a library we do want PRs for new majors of the toolchain.
- No `github-actions` section — the repo has no workflows yet; add it together with CI.