### PR TITLE
fix(security): enforce Apple chain shape, marker OIDs and CA constraint in JWS verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "1.4.0-pre.6",
       "license": "MIT",
       "dependencies": {
-        "jose": "^6.2.3"
+        "@peculiar/x509": "^2.0.0",
+        "jose": "^6.2.3",
+        "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
-        "@peculiar/x509": "^2.0.0",
         "@stylistic/eslint-plugin": "^2.13.0",
         "@types/node": "^25.9.3",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
@@ -20,7 +21,6 @@
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",
         "eslint-plugin-simple-import-sort": "^13.0.0",
-        "reflect-metadata": "^0.2.2",
         "tsdown": "^0.22.2",
         "typedoc": "^0.28.19",
         "typescript": "^6.0.3",
@@ -371,7 +371,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
       "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -385,7 +384,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
       "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -398,7 +396,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
       "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -411,7 +408,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
       "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.8.0",
@@ -426,7 +422,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
       "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -439,7 +434,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
       "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.8.0",
@@ -456,7 +450,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
       "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -469,7 +462,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
@@ -481,7 +473,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
       "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -494,7 +485,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
       "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.8.0",
@@ -507,7 +497,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -517,7 +506,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-2.0.0.tgz",
       "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.6.0",
@@ -1183,7 +1171,6 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
@@ -2561,7 +2548,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -2571,7 +2557,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -2598,7 +2583,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/resolve-pkg-maps": {
@@ -3194,14 +3178,12 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
       "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"
@@ -3214,7 +3196,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -4087,7 +4068,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
       "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4100,7 +4080,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
       "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4112,7 +4091,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
       "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4124,7 +4102,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
       "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-cms": "^2.8.0",
         "@peculiar/asn1-pkcs8": "^2.8.0",
@@ -4138,7 +4115,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
       "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4150,7 +4126,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
       "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-cms": "^2.8.0",
         "@peculiar/asn1-pfx": "^2.8.0",
@@ -4166,7 +4141,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
       "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4178,7 +4152,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
-      "dev": true,
       "requires": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
@@ -4189,7 +4162,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
       "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/utils": "^2.0.2",
@@ -4201,7 +4173,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
       "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/asn1-x509": "^2.8.0",
@@ -4213,7 +4184,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.8.1"
       }
@@ -4222,7 +4192,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-2.0.0.tgz",
       "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
-      "dev": true,
       "requires": {
         "@peculiar/asn1-cms": "^2.6.0",
         "@peculiar/asn1-csr": "^2.6.0",
@@ -4664,7 +4633,6 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
-      "dev": true,
       "requires": {
         "pvtsutils": "^1.3.6",
         "pvutils": "^1.1.5",
@@ -5498,7 +5466,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.8.1"
       }
@@ -5506,8 +5473,7 @@
     "pvutils": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "dev": true
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
     },
     "quansync": {
       "version": "1.0.0",
@@ -5518,8 +5484,7 @@
     "reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "resolve-pkg-maps": {
       "version": "1.0.0",
@@ -5844,14 +5809,12 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsyringe": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
       "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       },
@@ -5859,8 +5822,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "Apple IAP"
   ],
   "devDependencies": {
-    "@peculiar/x509": "^2.0.0",
     "@stylistic/eslint-plugin": "^2.13.0",
     "@types/node": "^25.9.3",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
@@ -35,14 +34,15 @@
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "reflect-metadata": "^0.2.2",
     "tsdown": "^0.22.2",
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "jose": "^6.2.3"
+    "@peculiar/x509": "^2.0.0",
+    "jose": "^6.2.3",
+    "reflect-metadata": "^0.2.2"
   },
   "exports": {
     ".": {

--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -1,23 +1,56 @@
+import 'reflect-metadata'
+
 import { X509Certificate } from 'node:crypto'
 
+import { X509Certificate as ParsedCertificate } from '@peculiar/x509'
 import * as jose from 'jose'
 
 import { APPLE_ROOT_CA } from './applerootca'
 import { CertificateVerificationError } from './errors'
 
+// Object identifiers Apple places on its App Store signing certificates.
+// https://www.apple.com/certificateauthority/pdf/Apple_WWDR_CPS_v1.30.pdf
+const APPLE_LEAF_OID = '1.2.840.113635.100.6.11.1'
+const APPLE_INTERMEDIATE_OID = '1.2.840.113635.100.6.2.1'
+
+function hasExtension (pem: string, oid: string): boolean {
+  return new ParsedCertificate(pem).getExtension(oid) !== null
+}
+
 /**
  * Confirms the authenticity of a certificate chain found in the x5c field of a JWS decoded header.
- * Each certificate should be valid and endorsed by the specified root CA.
+ *
+ * Mirrors the checks Apple's own server library performs: the chain must be exactly
+ * [leaf, intermediate, root], the leaf must carry the App Store marker extension, the
+ * intermediate must be a CA carrying the Apple CA marker extension, every certificate
+ * must be within its validity window and signed by the next one, and the root must
+ * match the pinned fingerprint.
  */
 function verifyCertificates (certs: string[], rootCA: string) {
   if (certs.length === 0) {
     throw new CertificateVerificationError(certs, 'No certificates provided')
   }
 
+  if (certs.length !== 3) {
+    throw new CertificateVerificationError(certs, 'Expected a certificate chain of exactly three certificates')
+  }
+
   const now = new Date()
   const x509certs = certs.map(c => new X509Certificate(c))
   if (!x509certs.every(cert => new Date(cert.validFrom) < now && now < new Date(cert.validTo))) {
     throw new CertificateVerificationError(certs, 'Certificate dates are invalid')
+  }
+
+  if (!hasExtension(certs[0], APPLE_LEAF_OID)) {
+    throw new CertificateVerificationError(certs, 'Leaf certificate is missing the App Store signing marker extension')
+  }
+
+  if (!hasExtension(certs[1], APPLE_INTERMEDIATE_OID)) {
+    throw new CertificateVerificationError(certs, 'Intermediate certificate is missing the Apple CA marker extension')
+  }
+
+  if (!x509certs[1].ca) {
+    throw new CertificateVerificationError(certs, 'Intermediate certificate is not a certificate authority')
   }
 
   for (let i = 0; i < x509certs.length - 1; i++) {

--- a/test/certChain.ts
+++ b/test/certChain.ts
@@ -10,6 +10,21 @@ x509.cryptoProvider.set(webcrypto as Crypto)
 
 const ALG = { name: 'ECDSA', namedCurve: 'P-256', hash: 'SHA-256' }
 
+// Apple marker extensions verifySignedPayload requires on the chain.
+const APPLE_LEAF_OID = '1.2.840.113635.100.6.11.1'
+const APPLE_INTERMEDIATE_OID = '1.2.840.113635.100.6.2.1'
+const DER_NULL = new Uint8Array([0x05, 0x00])
+
+export interface TestCertChainOptions {
+  expired?: boolean
+  /** Omit the App Store signing marker extension from the leaf certificate. */
+  withoutLeafMarker?: boolean
+  /** Omit the Apple CA marker extension from the intermediate certificate. */
+  withoutIntermediateMarker?: boolean
+  /** Issue the intermediate without the CA basic constraint. */
+  intermediateNotCa?: boolean
+}
+
 export interface TestCertChain {
   /**
    * SHA-256 fingerprint of the root certificate, in the format verifySignedPayload expects.
@@ -17,7 +32,7 @@ export interface TestCertChain {
   rootFingerprint: string
 
   /**
-   * The [leaf, root] certificates as base64 DER, as carried in the JWS x5c header.
+   * The [leaf, intermediate, root] certificates as base64 DER, as carried in the JWS x5c header.
    */
   x5c: string[]
 
@@ -27,12 +42,12 @@ export interface TestCertChain {
   leafKey: CryptoKey
 
   /**
-   * Signs a payload as a compact JWS with an x5c header of [leaf, root].
+   * Signs a payload as a compact JWS with an x5c header of [leaf, intermediate, root].
    */
   sign (payload: object): Promise<string>
 }
 
-export async function createTestCertChain (options: { expired?: boolean } = {}): Promise<TestCertChain> {
+export async function createTestCertChain (options: TestCertChainOptions = {}): Promise<TestCertChain> {
   const dayMs = 24 * 60 * 60 * 1000
   const notBefore = new Date(Date.now() - (options.expired ? 2 * dayMs : dayMs))
   const notAfter = new Date(Date.now() + (options.expired ? -dayMs : dayMs))
@@ -48,21 +63,40 @@ export async function createTestCertChain (options: { expired?: boolean } = {}):
     extensions: [new x509.BasicConstraintsExtension(true, undefined, true)],
   })
 
-  const leafKeys = await webcrypto.subtle.generateKey(ALG, true, ['sign', 'verify'])
-  const leafCert = await x509.X509CertificateGenerator.create({
+  const intermediateKeys = await webcrypto.subtle.generateKey(ALG, true, ['sign', 'verify'])
+  const intermediateExtensions = [
+    ...(options.intermediateNotCa ? [] : [new x509.BasicConstraintsExtension(true, undefined, true)]),
+    ...(options.withoutIntermediateMarker ? [] : [new x509.Extension(APPLE_INTERMEDIATE_OID, false, DER_NULL)]),
+  ]
+  const intermediateCert = await x509.X509CertificateGenerator.create({
     serialNumber: '02',
-    subject: 'CN=Test Leaf',
+    subject: 'CN=Test Intermediate CA',
     issuer: rootCert.subject,
     notBefore,
     notAfter,
     signingAlgorithm: ALG,
-    publicKey: leafKeys.publicKey,
+    publicKey: intermediateKeys.publicKey,
     signingKey: rootKeys.privateKey,
+    extensions: intermediateExtensions,
+  })
+
+  const leafKeys = await webcrypto.subtle.generateKey(ALG, true, ['sign', 'verify'])
+  const leafCert = await x509.X509CertificateGenerator.create({
+    serialNumber: '03',
+    subject: 'CN=Test Leaf',
+    issuer: intermediateCert.subject,
+    notBefore,
+    notAfter,
+    signingAlgorithm: ALG,
+    publicKey: leafKeys.publicKey,
+    signingKey: intermediateKeys.privateKey,
+    extensions: options.withoutLeafMarker ? [] : [new x509.Extension(APPLE_LEAF_OID, false, DER_NULL)],
   })
 
   const rootFingerprint = new X509Certificate(rootCert.toString('pem')).fingerprint256
   const x5c = [
     Buffer.from(leafCert.rawData).toString('base64'),
+    Buffer.from(intermediateCert.rawData).toString('base64'),
     Buffer.from(rootCert.rawData).toString('base64'),
   ]
 
@@ -70,11 +104,7 @@ export async function createTestCertChain (options: { expired?: boolean } = {}):
     rootFingerprint,
     x5c,
     leafKey: leafKeys.privateKey,
-    async sign (payload: object): Promise<string> {
-      return new jose.CompactSign(new TextEncoder().encode(JSON.stringify(payload)))
-        .setProtectedHeader({ alg: 'ES256', x5c })
-        .sign(leafKeys.privateKey)
-    },
+    sign: (payload: object) => signWithChain(payload, x5c, leafKeys.privateKey),
   }
 }
 

--- a/test/verifySignedPayload.test.ts
+++ b/test/verifySignedPayload.test.ts
@@ -60,10 +60,37 @@ describe('verifySignedPayload', () => {
     await expect(verifySignedPayload(jws, expiredChain.rootFingerprint)).rejects.toThrow('Certificate dates are invalid')
   })
 
-  it('rejects a payload whose leaf certificate is not issued by the presented root', async () => {
+  it('rejects a payload whose chain does not lead to the presented root', async () => {
     const otherChain = await createTestCertChain()
-    const jws = await signWithChain({ hello: 'world' }, [chain.x5c[0], otherChain.x5c[1]], chain.leafKey)
+    const jws = await signWithChain({ hello: 'world' }, [chain.x5c[0], chain.x5c[1], otherChain.x5c[2]], chain.leafKey)
 
     await expect(verifySignedPayload(jws, otherChain.rootFingerprint)).rejects.toThrow(CertificateVerificationError)
+  })
+
+  it('rejects a chain that is not exactly three certificates long', async () => {
+    const jws = await signWithChain({ hello: 'world' }, [chain.x5c[0], chain.x5c[2]], chain.leafKey)
+
+    await expect(verifySignedPayload(jws, chain.rootFingerprint)).rejects.toThrow('exactly three certificates')
+  })
+
+  it('rejects a leaf certificate without the App Store signing marker extension', async () => {
+    const noMarker = await createTestCertChain({ withoutLeafMarker: true })
+    const jws = await noMarker.sign({ hello: 'world' })
+
+    await expect(verifySignedPayload(jws, noMarker.rootFingerprint)).rejects.toThrow('App Store signing marker')
+  })
+
+  it('rejects an intermediate certificate without the Apple CA marker extension', async () => {
+    const noMarker = await createTestCertChain({ withoutIntermediateMarker: true })
+    const jws = await noMarker.sign({ hello: 'world' })
+
+    await expect(verifySignedPayload(jws, noMarker.rootFingerprint)).rejects.toThrow('Apple CA marker')
+  })
+
+  it('rejects an intermediate certificate that is not a certificate authority', async () => {
+    const notCa = await createTestCertChain({ intermediateNotCa: true })
+    const jws = await notCa.sign({ hello: 'world' })
+
+    await expect(verifySignedPayload(jws, notCa.rootFingerprint)).rejects.toThrow(CertificateVerificationError)
   })
 })


### PR DESCRIPTION
`verifyCertificates()` checked only validity dates, pairwise issuance/signatures, and the pinned root fingerprint. That accepts **any end-entity certificate chaining to Apple Root CA G3** — e.g. a developer's WWDR-issued signing certificate — as a valid notification signer, and (since the CA flag was never consulted) even lets such a cert mint a passing child. Apple's own [app-store-server-library-node](https://github.com/apple/app-store-server-library-node) enforces all of the checks added here:

- chain must be exactly `[leaf, intermediate, root]` (length 3);
- leaf must carry the App Store signing marker extension (`1.2.840.113635.100.6.11.1`);
- intermediate must carry the Apple CA marker (`1.2.840.113635.100.6.2.1`) **and** the CA basic constraint;
- existing date / issuance / signature / pinned-root checks retained.

Extension lookup needs ASN.1 parsing that `node:crypto`'s `X509Certificate` doesn't expose, so `@peculiar/x509` (already used by the test suite) moves to runtime dependencies along with its `reflect-metadata` requirement.

Tests: the in-test CA now issues Apple-shaped 3-cert chains with marker extensions; five new negative tests (wrong length, missing leaf marker, missing intermediate marker, non-CA intermediate, foreign root). 41 tests green.