### PR TITLE
fix: use binary certificate validity dates with inclusive bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Full API reference: https://tamtamchik.github.io/apple-iap-tools
 npm install @tamtamchik/apple-iap-tools
 ```
 
-Requires Node.js 22 or later.
+Requires Node.js 22.10 or later.
 
 ## Quick start: handle a notification webhook
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.10.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.10.0"
   },
   "scripts": {
     "build": "tsdown",

--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -37,7 +37,8 @@ function verifyCertificates (certs: string[], rootCA: string) {
 
   const now = new Date()
   const x509certs = certs.map(c => new X509Certificate(c))
-  if (!x509certs.every(cert => new Date(cert.validFrom) < now && now < new Date(cert.validTo))) {
+  // validFromDate/validToDate come from the binary certificate fields; RFC 5280 validity bounds are inclusive.
+  if (!x509certs.every(cert => cert.validFromDate <= now && now <= cert.validToDate)) {
     throw new CertificateVerificationError(certs, 'Certificate dates are invalid')
   }
 

--- a/test/verifySignedPayload.test.ts
+++ b/test/verifySignedPayload.test.ts
@@ -1,5 +1,5 @@
 import * as jose from 'jose'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { CertificateVerificationError } from '../src/jws/errors'
 import { verifySignedPayload } from '../src/jws/verifySignedPayload'
@@ -58,6 +58,25 @@ describe('verifySignedPayload', () => {
     const jws = await expiredChain.sign({ hello: 'world' })
 
     await expect(verifySignedPayload(jws, expiredChain.rootFingerprint)).rejects.toThrow('Certificate dates are invalid')
+  })
+
+  describe('validity window boundaries (RFC 5280: inclusive)', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('accepts a certificate at the exact notAfter instant and rejects one second later', async () => {
+      const jws = await chain.sign({ hello: 'world' })
+      const { validToDate } = new (await import('node:crypto')).X509Certificate(Buffer.from(chain.x5c[0], 'base64'))
+
+      vi.useFakeTimers()
+
+      vi.setSystemTime(validToDate)
+      await expect(verifySignedPayload(jws, chain.rootFingerprint)).resolves.toEqual({ hello: 'world' })
+
+      vi.setSystemTime(new Date(validToDate.getTime() + 1000))
+      await expect(verifySignedPayload(jws, chain.rootFingerprint)).rejects.toThrow('Certificate dates are invalid')
+    })
   })
 
   it('rejects a payload whose chain does not lead to the presented root', async () => {


### PR DESCRIPTION
Fixes finding #5 of the pre-2.0 code review. Stacked on #23.

`new Date(cert.validFrom)` parsed OpenSSL's human-readable date strings (`'Dec 18 22:24:21 2023 GMT'`) whose interpretation is implementation-defined per ECMA-262 — a future V8 change could turn every chain into `Invalid Date` and halt all webhook verification with no code change in this repo. Switched to `validFromDate`/`validToDate`, which read the binary certificate fields directly.

Also: validity bounds are now inclusive (`<=`), matching RFC 5280 §4.1.2.5, and `engines.node` rises `>=22.0.0` → `>=22.10.0` — the accessors were backported in Node 22.10.