### PR TITLE
fix: normalize JWS verification failures into CertificateVerificationError

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ app.post('/apple/notifications', async (req, res) => {
     result = await decode(req.body)
   } catch (error) {
     if (error instanceof CertificateVerificationError) {
-      return res.sendStatus(401) // certificate chain didn't check out — likely a forged request
+      return res.sendStatus(401) // chain or signature didn't check out — a forged or corrupted request
     }
-    throw error // anything else (bad signature, malformed JSON) — let your error handler respond 5xx, Apple will retry
+    throw error // anything else is unexpected — let your error handler respond 5xx, Apple will retry
   }
 
   if (isDataNotification(result)) {

--- a/src/jws/errors.ts
+++ b/src/jws/errors.ts
@@ -1,8 +1,8 @@
 export class CertificateVerificationError extends Error {
   certs: string[]
 
-  constructor (certs: string[], message?: string) {
-    super(message ?? 'Certificate verification failed')
+  constructor (certs: string[], message?: string, options?: ErrorOptions) {
+    super(message ?? 'Certificate verification failed', options)
     this.certs = certs
   }
 }

--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -83,10 +83,12 @@ function verifyCertificates (certs: string[], rootCA: string) {
  */
 export async function verifySignedPayload<T> (signedPayload: string, rootCA: string = APPLE_ROOT_CA): Promise<T> {
   let payload: Uint8Array
+  let presentedCerts: string[] = []
 
   try {
     ({ payload } = await jose.compactVerify(signedPayload, (protectedHeader) => {
       const certs = protectedHeader.x5c?.map(c => `-----BEGIN CERTIFICATE-----\n${c}\n-----END CERTIFICATE-----`) ?? []
+      presentedCerts = certs
 
       verifyCertificates(certs, rootCA)
 
@@ -97,8 +99,13 @@ export async function verifySignedPayload<T> (signedPayload: string, rootCA: str
       throw error
     }
 
-    // Normalize jose failures (bad signature, malformed JWS) into the documented error type.
-    throw new CertificateVerificationError([], error instanceof Error ? error.message : 'JWS verification failed')
+    // Normalize jose failures (bad signature, malformed JWS) into the documented error
+    // type, keeping the original error as the cause and the presented chain inspectable.
+    throw new CertificateVerificationError(
+      presentedCerts,
+      error instanceof Error ? error.message : 'JWS verification failed',
+      { cause: error },
+    )
   }
 
   const decodedPayload = new TextDecoder().decode(payload)

--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -79,16 +79,27 @@ function verifyCertificates (certs: string[], rootCA: string) {
  * @param signedPayload The JWS string to verify.
  * @param rootCA SHA-256 fingerprint of the expected root CA certificate. Defaults to the Apple Root CA - G3.
  *
- * @throws {CertificateVerificationError} If the signature cannot be verified.
+ * @throws {CertificateVerificationError} If the certificate chain or the signature cannot be verified.
  */
 export async function verifySignedPayload<T> (signedPayload: string, rootCA: string = APPLE_ROOT_CA): Promise<T> {
-  const { payload } = await jose.compactVerify(signedPayload, (protectedHeader) => {
-    const certs = protectedHeader.x5c?.map(c => `-----BEGIN CERTIFICATE-----\n${c}\n-----END CERTIFICATE-----`) ?? []
+  let payload: Uint8Array
 
-    verifyCertificates(certs, rootCA)
+  try {
+    ({ payload } = await jose.compactVerify(signedPayload, (protectedHeader) => {
+      const certs = protectedHeader.x5c?.map(c => `-----BEGIN CERTIFICATE-----\n${c}\n-----END CERTIFICATE-----`) ?? []
 
-    return jose.importX509(certs[0], protectedHeader.alg)
-  })
+      verifyCertificates(certs, rootCA)
+
+      return jose.importX509(certs[0], protectedHeader.alg)
+    }))
+  } catch (error) {
+    if (error instanceof CertificateVerificationError) {
+      throw error
+    }
+
+    // Normalize jose failures (bad signature, malformed JWS) into the documented error type.
+    throw new CertificateVerificationError([], error instanceof Error ? error.message : 'JWS verification failed')
+  }
 
   const decodedPayload = new TextDecoder().decode(payload)
 

--- a/test/decode.test.ts
+++ b/test/decode.test.ts
@@ -7,6 +7,7 @@ import {
   isExternalPurchaseTokenNotification,
   isSummaryNotification,
 } from '../src/appstoreservernotifications/v2/decode'
+import { CertificateVerificationError } from '../src/jws/errors'
 
 import { createTestCertChain, TestCertChain } from './certChain'
 
@@ -152,6 +153,6 @@ describe('decode', () => {
     const otherChain = await createTestCertChain()
     const signedPayload = await otherChain.sign({ ...base, notificationType: 'TEST' })
 
-    await expect(decode({ signedPayload }, chain.rootFingerprint)).rejects.toThrow()
+    await expect(decode({ signedPayload }, chain.rootFingerprint)).rejects.toThrow(CertificateVerificationError)
   })
 })

--- a/test/verifySignedPayload.test.ts
+++ b/test/verifySignedPayload.test.ts
@@ -43,7 +43,7 @@ describe('verifySignedPayload', () => {
     const [header, , signature] = jws.split('.')
     const forged = Buffer.from(JSON.stringify({ amount: 1000000 })).toString('base64url')
 
-    await expect(verifySignedPayload(`${header}.${forged}.${signature}`, chain.rootFingerprint)).rejects.toThrow()
+    await expect(verifySignedPayload(`${header}.${forged}.${signature}`, chain.rootFingerprint)).rejects.toThrow(CertificateVerificationError)
   })
 
   it('rejects a payload signed by a key outside the certificate chain', async () => {


### PR DESCRIPTION
Fixes finding #7 of the pre-2.0 code review. Stacked on #24.

The docblock promised `@throws CertificateVerificationError if the signature cannot be verified`, but a payload with a **valid Apple chain and a forged signature** made `jose.compactVerify` throw its own `JWSSignatureVerificationFailed` — so the README's recommended handler classified an actual forgery attempt as a server fault (5xx, retried by the sender) instead of rejecting it with 401, and error-class-based metrics misattributed forgeries.

- `verifySignedPayload` now wraps jose failures (bad signature, malformed JWS) into `CertificateVerificationError`, preserving the original message; chain errors pass through unchanged.
- Tests pin the error class for tampered payloads and untrusted chains (previously bare `rejects.toThrow()` — any exception class passed).
- README handler comment updated: 401 now covers both chain and signature failures.