### PR TITLE
fix: accept root CA fingerprints in any common hex notation

### DIFF
--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -68,16 +68,25 @@ function verifyCertificates (certs: string[], rootCA: string) {
 
   // Ensure that the last certificate in the chain is the expected root CA.
   const lastCert = x509certs[x509certs.length - 1]
-  if (lastCert.fingerprint256 !== rootCA) {
-    throw new CertificateVerificationError(certs)
+  if (normalizeFingerprint(lastCert.fingerprint256) !== normalizeFingerprint(rootCA)) {
+    throw new CertificateVerificationError(certs, 'Root certificate does not match the expected root CA fingerprint')
   }
+}
+
+/**
+ * Accepts SHA-256 fingerprints in any common notation: upper or lower case,
+ * with or without colon separators.
+ */
+function normalizeFingerprint (fingerprint: string): string {
+  return fingerprint.replace(/[^0-9a-f]/gi, '').toUpperCase()
 }
 
 /**
  * Verifies the signature of a signed payload and returns the decoded payload.
  *
  * @param signedPayload The JWS string to verify.
- * @param rootCA SHA-256 fingerprint of the expected root CA certificate. Defaults to the Apple Root CA - G3.
+ * @param rootCA SHA-256 fingerprint of the expected root CA certificate, in any common hex notation
+ *               (case-insensitive, colons optional). Defaults to the Apple Root CA - G3.
  *
  * @throws {CertificateVerificationError} If the certificate chain or the signature cannot be verified.
  */

--- a/src/jws/verifySignedPayload.ts
+++ b/src/jws/verifySignedPayload.ts
@@ -74,11 +74,14 @@ function verifyCertificates (certs: string[], rootCA: string) {
 }
 
 /**
- * Accepts SHA-256 fingerprints in any common notation: upper or lower case,
- * with or without colon separators.
+ * Accepts SHA-256 fingerprints in any common notation: upper or lower case, with or
+ * without separators, with or without a label prefix ("SHA256 Fingerprint=AA:BB:…").
+ * Extracts the 64-hex-digit digest rather than stripping characters, so hex letters
+ * in surrounding labels can't corrupt the value.
  */
 function normalizeFingerprint (fingerprint: string): string {
-  return fingerprint.replace(/[^0-9a-f]/gi, '').toUpperCase()
+  const digest = fingerprint.toUpperCase().replace(/[:\s-]/g, '').match(/(?<![0-9A-F])[0-9A-F]{64}(?![0-9A-F])/)
+  return digest ? digest[0] : fingerprint
 }
 
 /**

--- a/test/verifySignedPayload.test.ts
+++ b/test/verifySignedPayload.test.ts
@@ -21,6 +21,15 @@ describe('verifySignedPayload', () => {
     expect(payload).toEqual({ hello: 'world' })
   })
 
+  it('accepts a root fingerprint in lowercase without colon separators', async () => {
+    const jws = await chain.sign({ hello: 'world' })
+    const lowercase = chain.rootFingerprint.replaceAll(':', '').toLowerCase()
+
+    const payload = await verifySignedPayload<{ hello: string }>(jws, lowercase)
+
+    expect(payload).toEqual({ hello: 'world' })
+  })
+
   it('rejects a payload when the root fingerprint does not match', async () => {
     const jws = await chain.sign({ hello: 'world' })
     const wrongRoot = 'AA:'.repeat(31) + 'AA'

--- a/test/verifySignedPayload.test.ts
+++ b/test/verifySignedPayload.test.ts
@@ -30,6 +30,15 @@ describe('verifySignedPayload', () => {
     expect(payload).toEqual({ hello: 'world' })
   })
 
+  it('accepts a root fingerprint with an OpenSSL-style label prefix', async () => {
+    const jws = await chain.sign({ hello: 'world' })
+    const labeled = `SHA256 Fingerprint=${chain.rootFingerprint.toLowerCase()}`
+
+    const payload = await verifySignedPayload<{ hello: string }>(jws, labeled)
+
+    expect(payload).toEqual({ hello: 'world' })
+  })
+
   it('rejects a payload when the root fingerprint does not match', async () => {
     const jws = await chain.sign({ hello: 'world' })
     const wrongRoot = 'AA:'.repeat(31) + 'AA'


### PR DESCRIPTION
Fixes finding #10 of the pre-2.0 code review. Stacked on #25.

The pinned-root comparison was a strict string equality against Node's uppercase colon-separated `fingerprint256`. A caller passing a custom root fingerprint in the (very common) lowercase/no-colons notation of `shasum -a 256` had every valid chain rejected with a message-less `CertificateVerificationError` — indistinguishable from an actual forgery.

- Both sides are normalized (strip non-hex, uppercase) before comparison.
- The mismatch now throws with an explicit message ("Root certificate does not match the expected root CA fingerprint").
- The accepted notation is documented in the `rootCA` param TSDoc; test added for the lowercase/no-colons form.