### PR TITLE
fix: decode data notifications without signedTransactionInfo

### DIFF
--- a/src/appstoreservernotifications/v2/body/data.ts
+++ b/src/appstoreservernotifications/v2/body/data.ts
@@ -74,7 +74,7 @@ export interface data {
    * @link https://developer.apple.com/documentation/appstoreservernotifications/bundleversion
    * @version 2.0+
    */
-  bundleVersion: string
+  bundleVersion?: string
 
   /**
    * The reason the customer requested a refund.
@@ -98,10 +98,13 @@ export interface data {
   /**
    * Transaction information signed by the App Store, in JSON Web Signature (JWS) format.
    *
+   * Conditionally present: notifications such as TEST and RENEWAL_EXTENSION carry
+   * a data object without signed transaction information.
+   *
    * @link https://developer.apple.com/documentation/appstoreservernotifications/jwstransaction
    * @version 2.0+
    */
-  signedTransactionInfo: string
+  signedTransactionInfo?: string
 
   status?: status
 }

--- a/src/appstoreservernotifications/v2/decode.ts
+++ b/src/appstoreservernotifications/v2/decode.ts
@@ -21,7 +21,13 @@ interface DecodeResultGeneric {
 
 interface DecodeResultData extends DecodeResultGeneric {
   body: responseBodyV2DecodedData
-  transactionPayload: jwsTransactionDecodedPayload
+
+  /**
+   * The decoded transaction information. Absent for data notifications that
+   * carry no signedTransactionInfo, such as TEST.
+   */
+  transactionPayload: jwsTransactionDecodedPayload | undefined
+
   pendingRenewalInfoPayload: jwsRenewalInfoDecodedPayload | undefined
   appTransactionPayload?: never
 }
@@ -80,7 +86,10 @@ export async function decode (encodedBody: responseBodyV2, rootCA?: string): Pro
   const body = await verifySignedPayload<responseBodyV2Decoded>(encodedBody.signedPayload, rootCA)
 
   if (isDataNotificationBody(body)) {
-    const transactionPayload = await verifySignedPayload<jwsTransactionDecodedPayload>(body.data.signedTransactionInfo, rootCA)
+    let transactionPayload
+    if (body.data.signedTransactionInfo) {
+      transactionPayload = await verifySignedPayload<jwsTransactionDecodedPayload>(body.data.signedTransactionInfo, rootCA)
+    }
 
     let pendingRenewalInfoPayload
     if (body.data.signedRenewalInfo) {

--- a/src/appstoreservernotifications/v2/decode.ts
+++ b/src/appstoreservernotifications/v2/decode.ts
@@ -23,8 +23,8 @@ interface DecodeResultData extends DecodeResultGeneric {
   body: responseBodyV2DecodedData
 
   /**
-   * The decoded transaction information. Absent for data notifications that
-   * carry no signedTransactionInfo, such as TEST.
+   * The decoded transaction information. `undefined` for data notifications
+   * that carry no signedTransactionInfo, such as TEST.
    */
   transactionPayload: jwsTransactionDecodedPayload | undefined
 
@@ -86,15 +86,13 @@ export async function decode (encodedBody: responseBodyV2, rootCA?: string): Pro
   const body = await verifySignedPayload<responseBodyV2Decoded>(encodedBody.signedPayload, rootCA)
 
   if (isDataNotificationBody(body)) {
-    let transactionPayload
-    if (body.data.signedTransactionInfo) {
-      transactionPayload = await verifySignedPayload<jwsTransactionDecodedPayload>(body.data.signedTransactionInfo, rootCA)
-    }
+    const transactionPayload = body.data.signedTransactionInfo
+      ? await verifySignedPayload<jwsTransactionDecodedPayload>(body.data.signedTransactionInfo, rootCA)
+      : undefined
 
-    let pendingRenewalInfoPayload
-    if (body.data.signedRenewalInfo) {
-      pendingRenewalInfoPayload = await verifySignedPayload<jwsRenewalInfoDecodedPayload>(body.data.signedRenewalInfo, rootCA)
-    }
+    const pendingRenewalInfoPayload = body.data.signedRenewalInfo
+      ? await verifySignedPayload<jwsRenewalInfoDecodedPayload>(body.data.signedRenewalInfo, rootCA)
+      : undefined
 
     return { body, transactionPayload, pendingRenewalInfoPayload }
   }

--- a/test/decode.test.ts
+++ b/test/decode.test.ts
@@ -148,6 +148,26 @@ describe('decode', () => {
     expect('appTransactionPayload' in result).toBe(false)
   })
 
+  it('decodes a TEST notification whose data carries no signed transaction info', async () => {
+    const signedPayload = await chain.sign({
+      ...base,
+      notificationType: 'TEST',
+      data: {
+        bundleId: 'com.example.app',
+        environment: 'Sandbox',
+      },
+    })
+
+    const result = await decode({ signedPayload }, chain.rootFingerprint)
+
+    expect(isDataNotification(result)).toBe(true)
+    if (isDataNotification(result)) {
+      expect(result.body.notificationType).toBe('TEST')
+      expect(result.transactionPayload).toBeUndefined()
+      expect(result.pendingRenewalInfoPayload).toBeUndefined()
+    }
+  })
+
   it('rejects a notification signed by an untrusted chain', async () => {
     const otherChain = await createTestCertChain()
     const signedPayload = await otherChain.sign({ ...base, notificationType: 'TEST' })


### PR DESCRIPTION
Fixes finding #2 of the pre-2.0 code review (critical).

`decode()` unconditionally verified `body.data.signedTransactionInfo`, but Apple sends data-notifications **without** it — notably `TEST` (the notification this library's own `requestTestNotification()` asks Apple to send) and `RENEWAL_EXTENSION`. `jose.compactVerify(undefined)` threw `JWSInvalid`, the README-style handler answered 5xx, and Apple retried the notification forever — the first user who pinged their webhook hit it.

- `data.signedTransactionInfo` and `data.bundleVersion` are now optional, matching Apple's schema (every `data` field is conditionally present).
- `decode()` verifies the transaction JWS only when present; `DecodeResultData.transactionPayload` is typed `jwsTransactionDecodedPayload | undefined` accordingly.
- Test added: TEST notification with metadata-only `data` decodes cleanly with both payloads `undefined`.