### PR TITLE
fix: exhaustive payload variant dispatch in decode

### DIFF
--- a/src/appstoreservernotifications/v2/decode.ts
+++ b/src/appstoreservernotifications/v2/decode.ts
@@ -112,7 +112,11 @@ export async function decode (encodedBody: responseBodyV2, rootCA?: string): Pro
     return { body }
   }
 
-  if (isSummaryNotificationBody(body) || isExternalPurchaseTokenNotificationBody(body)) {
+  if (isSummaryNotificationBody(body)) {
+    return { body }
+  }
+
+  if (isExternalPurchaseTokenNotificationBody(body)) {
     return { body }
   }
 

--- a/src/appstoreservernotifications/v2/decode.ts
+++ b/src/appstoreservernotifications/v2/decode.ts
@@ -15,6 +15,10 @@ const isDataNotificationBody = (body: responseBodyV2Decoded): body is responseBo
 
 const isAppDataNotificationBody = (body: responseBodyV2Decoded): body is responseBodyV2DecodedAppData => !!body.appData
 
+const isSummaryNotificationBody = (body: responseBodyV2Decoded): body is responseBodyV2DecodedSummary => !!body.summary
+
+const isExternalPurchaseTokenNotificationBody = (body: responseBodyV2Decoded): body is responseBodyV2DecodedExternalPurchaseToken => !!body.externalPurchaseToken
+
 interface DecodeResultGeneric {
   body: responseBodyV2Decoded
 }
@@ -108,5 +112,13 @@ export async function decode (encodedBody: responseBodyV2, rootCA?: string): Pro
     return { body }
   }
 
-  return { body } as DecodeResult
+  if (isSummaryNotificationBody(body) || isExternalPurchaseTokenNotificationBody(body)) {
+    return { body }
+  }
+
+  // Exhaustiveness check: adding a new variant to responseBodyV2Decoded must fail
+  // compilation here until decode() handles it. At runtime an unrecognized payload
+  // (a variant newer than this library) is still returned for the caller to inspect.
+  const unhandled: never = body
+  return { body: unhandled }
 }


### PR DESCRIPTION
Fixes finding #8 of the pre-2.0 code review. Stacked on #27.

`decode()` ended with `return { body } as DecodeResult` — a load-bearing cast covering the summary/externalPurchaseToken variants. When Apple adds a fifth payload variant (exactly how `appData` arrived), the union grows, the cast still compiles, and consumers' guard chains silently fall through with no signal.

- Added `isSummaryNotificationBody` / `isExternalPurchaseTokenNotificationBody` guards; each variant now returns from its own narrowed branch.
- The trailing cast is replaced by a `never` exhaustiveness check: adding a variant to `responseBodyV2Decoded` fails compilation here until `decode()` handles it.
- Runtime behavior for payloads newer than the library is unchanged — the body is still returned for the caller to inspect rather than throwing.