### PR TITLE
fix: content-driven Apple error parsing, tolerate non-JSON error bodies

### DIFF
--- a/src/appstoreserverapi/Service.ts
+++ b/src/appstoreserverapi/Service.ts
@@ -197,12 +197,28 @@ export class Service {
       throw new InvalidAuthorizationError()
     }
 
+    // Any error status whose body is Apple's JSON error shape becomes a ServerAPIError,
+    // regardless of the particular status code. Non-JSON bodies (a gateway or proxy
+    // answering for Apple) fall through to the generic error instead of a parse failure.
     // https://developer.apple.com/documentation/appstoreserverapi/error-codes
-    if ([400, 404, 429, 500].includes(result.status)) {
-      const error = await result.json() as ServerAPIErrorResponse
+    const error = await this.parseErrorResponse(result)
+    if (error) {
       throw new ServerAPIError(result.status, error, result.headers)
     }
 
     throw new Error(`Unexpected response from App Store: ${result.statusText} (${result.status})`)
+  }
+
+  private async parseErrorResponse (result: Response): Promise<ServerAPIErrorResponse | undefined> {
+    try {
+      const parsed: unknown = await result.json()
+      if (parsed && typeof parsed === 'object' && typeof (parsed as ServerAPIErrorResponse).errorCode === 'number') {
+        return parsed as ServerAPIErrorResponse
+      }
+    } catch {
+      // Body is empty or not JSON.
+    }
+
+    return undefined
   }
 }

--- a/src/appstoreserverapi/Service.ts
+++ b/src/appstoreserverapi/Service.ts
@@ -212,7 +212,11 @@ export class Service {
   private async parseErrorResponse (result: Response): Promise<ServerAPIErrorResponse | undefined> {
     try {
       const parsed: unknown = await result.json()
-      if (parsed && typeof parsed === 'object' && typeof (parsed as ServerAPIErrorResponse).errorCode === 'number') {
+      if (
+        parsed && typeof parsed === 'object' && !Array.isArray(parsed) &&
+        typeof (parsed as ServerAPIErrorResponse).errorCode === 'number' &&
+        typeof (parsed as ServerAPIErrorResponse).errorMessage === 'string'
+      ) {
         return parsed as ServerAPIErrorResponse
       }
     } catch {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -116,6 +116,21 @@ describe('Service', () => {
     expect((error as ServerAPIError).errorCode).toBe(4040010)
   })
 
+  it('throws a generic error instead of a parse failure when the error body is not JSON', async () => {
+    fetchMock.mockResolvedValue(new Response('<html>Service Unavailable</html>', { status: 500, statusText: 'Internal Server Error' }))
+
+    await expect(makeService().getTransactionInfo('t-1')).rejects.toThrow('Unexpected response from App Store: Internal Server Error (500)')
+  })
+
+  it('maps Apple error bodies on unlisted statuses to ServerAPIError', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ errorCode: 4030000, errorMessage: 'Forbidden.' }, 403))
+
+    const error = await makeService().getTransactionInfo('t-1').catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ServerAPIError)
+    expect((error as ServerAPIError).errorCode).toBe(4030000)
+  })
+
   it('exposes rate limit information on 429', async () => {
     fetchMock.mockResolvedValue(jsonResponse(
       { errorCode: 4290000, errorMessage: 'Rate limit exceeded.' },


### PR DESCRIPTION
Fixes finding #3 of the pre-2.0 code review.

`call()` assumed statuses 400/404/429/500 always carry Apple's JSON error body and ran `await result.json()` unguarded:

- a 500 with an empty/HTML body (load balancer or proxy answering during an outage) rejected with `SyntaxError: Unexpected end of JSON input` instead of the documented `ServerAPIError` — retry logic keyed on `isRetryable` never matched;
- statuses outside the hardcoded list (e.g. 403) discarded Apple's error body entirely.

Now the dispatch is content-driven: any non-OK, non-401 response whose body parses to Apple's `{ errorCode }` shape becomes a `ServerAPIError` regardless of status; anything else (non-JSON, foreign JSON) falls through to the generic `Error` with the status attached. Tests cover HTML-bodied 500 and Apple-bodied 403.