### PR TITLE
fix: defuse unhandled rejection from importing a malformed signing key

### DIFF
--- a/src/appstoreserverapi/Service.ts
+++ b/src/appstoreserverapi/Service.ts
@@ -62,6 +62,10 @@ export class Service {
     private readonly environment: ServiceEnvironment = ServiceEnvironment.Sandbox,
   ) {
     this.key = jose.importPKCS8(key, this.alg)
+    // A malformed key rejects the promise immediately; without a handler attached,
+    // Node treats it as an unhandled rejection and kills the process before the
+    // first API call ever awaits it. The error still surfaces on first use.
+    this.key.catch(() => undefined)
 
     // https://developer.apple.com/documentation/appstoreserverapi
     this.endpoint = environment === ServiceEnvironment.Sandbox

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -101,6 +101,16 @@ describe('Service', () => {
     await expect(makeService().getTransactionInfo('t-1')).rejects.toThrow('Unexpected response from App Store: Service Unavailable (503)')
   })
 
+  it('surfaces a malformed private key at call time instead of an unhandled rejection', async () => {
+    const service = new Service('not a pkcs8 key', 'key-id', 'issuer-id', 'com.example.app')
+
+    // Give the rejected import promise a macrotask to trigger a potential unhandled rejection.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    await expect(service.getTransactionInfo('t-1')).rejects.toThrow()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('throws InvalidAuthorizationError on 401', async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 401 }))
 


### PR DESCRIPTION
Fixes finding #4 of the pre-2.0 code review. Stacked on #29.

The constructor stored the `jose.importPKCS8` promise without any rejection handler. A malformed `.p8` key rejects that promise immediately; in the common pattern of constructing `Service` at module load and calling it on the first request, Node fires `unhandledRejection` and (by default since Node 15) **kills the process at startup** instead of surfacing the error in the caller's try/catch.

A no-op `.catch()` is attached in the constructor — the rejection is no longer unhandled, and the original error still surfaces on the first API call, where the caller can handle it. Test covers the construct-wait-call sequence (vitest itself fails on unhandled rejections, so the test guards the regression both ways).