### PR TITLE
fix: restore legacy receipt fields on ServerNotificationResponseBody

### DIFF
--- a/src/deprecated/notifications/v1/types/responseBodyV1.ts
+++ b/src/deprecated/notifications/v1/types/responseBodyV1.ts
@@ -1,3 +1,4 @@
+import { DeprecatedLatestReceiptInfo } from './deprecatedLatestReceiptInfo'
 import { ServerNotificationType } from './notificationTypeV1'
 import { BooleanString, ExpirationIntent } from './stringTypes'
 import { UnifiedReceipt } from './unifiedReceipt'
@@ -86,4 +87,32 @@ export interface ServerNotificationResponseBody {
    * A string that contains the app bundle version.
    */
   bvrs: string
+
+  /**
+   * The latest Base64-encoded app receipt.
+   *
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use the latest_receipt field found in the unified_receipt object instead.
+   */
+  latest_receipt?: string
+
+  /**
+   * The latest decoded app receipt.
+   *
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.Latest_receipt_info in the unified_receipt object instead.
+   */
+  latest_receipt_info?: DeprecatedLatestReceiptInfo
+
+  /**
+   * The latest expired Base64-encoded app receipt.
+   *
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use latest_receipt in the unified_receipt object instead.
+   */
+  latest_expired_receipt?: string
+
+  /**
+   * The latest decoded app receipts.
+   *
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.Latest_receipt_info in the unified_receipt object instead.
+   */
+  latest_expired_receipt_info?: DeprecatedLatestReceiptInfo[]
 }

--- a/src/deprecated/notifications/v1/types/responseBodyV1.ts
+++ b/src/deprecated/notifications/v1/types/responseBodyV1.ts
@@ -98,7 +98,7 @@ export interface ServerNotificationResponseBody {
   /**
    * The latest decoded app receipt.
    *
-   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.Latest_receipt_info in the unified_receipt object instead.
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.latest_receipt_info in the unified_receipt object instead.
    */
   latest_receipt_info?: DeprecatedLatestReceiptInfo
 
@@ -112,7 +112,7 @@ export interface ServerNotificationResponseBody {
   /**
    * The latest decoded app receipts.
    *
-   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.Latest_receipt_info in the unified_receipt object instead.
+   * @deprecated As of March 10, 2021 this object is no longer provided in production and sandbox environments. Use unified_receipt.latest_receipt_info in the unified_receipt object instead.
    */
   latest_expired_receipt_info?: DeprecatedLatestReceiptInfo[]
 }


### PR DESCRIPTION
Fixes finding #6 of the pre-2.0 code review.

The 1.3.6 release declared four optional legacy fields on `ServerNotificationResponseBody` that the v2 rewrite silently dropped: `latest_receipt`, `latest_receipt_info`, `latest_expired_receipt`, `latest_expired_receipt_info`. A 1.x consumer replaying stored/queued legacy notifications (`if (body.latest_receipt_info) …`) got TS2339 on upgrade with no migration note, and the re-exported `DeprecatedLatestReceiptInfo` type was orphaned — exported but referenced by nothing.

Restored verbatim from 1.3.6 with their original `@deprecated` annotations; `DeprecatedLatestReceiptInfo` is wired back into the interface.