### PR TITLE
fix: stop getLatestReceiptInfo from mutating the caller-provided array

### DIFF
--- a/src/deprecated/notifications/v1/helpers.ts
+++ b/src/deprecated/notifications/v1/helpers.ts
@@ -36,7 +36,7 @@ export function getLatestReceiptInfo (result: UnifiedReceipt | VerifyReceiptResp
   if (!result.latest_receipt_info) return null
 
   if (Array.isArray(result.latest_receipt_info)) {
-    const receipts = result.latest_receipt_info.sort((a, b) => +b.purchase_date_ms - +a.purchase_date_ms)
+    const receipts = [...result.latest_receipt_info].sort((a, b) => +b.purchase_date_ms - +a.purchase_date_ms)
     return receipts[0]
   }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -34,6 +34,14 @@ describe('v1 helpers', () => {
     expect(result?.original_transaction_id).toBe('b')
   })
 
+  it('getLatestReceiptInfo does not mutate the caller-provided array', () => {
+    const receipts = [receipt('a', '100'), receipt('b', '300'), receipt('c', '200')]
+
+    getLatestReceiptInfo({ latest_receipt_info: receipts } as UnifiedReceipt)
+
+    expect(receipts.map(r => r.original_transaction_id)).toEqual(['a', 'b', 'c'])
+  })
+
   it('getLatestReceiptInfo returns null when there is no receipt info', () => {
     expect(getLatestReceiptInfo({} as UnifiedReceipt)).toBeNull()
   })


### PR DESCRIPTION
Fixes finding #9 of the pre-2.0 code review.

`getLatestReceiptInfo` sorted `result.latest_receipt_info` in place — `Array.prototype.sort` mutates, so the caller's array was silently reordered newest-first (also via `getPendingRenewalInfo`, which calls it internally). Code relying on Apple's original ordering after calling the helper observed a different order. Pre-existing since at least 1.3.6, in a deprecated-but-exported module.

Sorting now happens on a copy; regression test asserts the input array keeps its order.