### PR TITLE
test: verify production path against real Apple payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist/
 node_modules/
 .DS_Store
 coverage
+
+# Local-only fixtures: real third-party Apple payloads, never committed.
+test/fixtures/*.local.json

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,41 @@
+# Local real-payload fixtures
+
+`realPayloads.test.ts` verifies genuine Apple-signed payloads against the default
+`Apple Root CA - G3` fingerprint — the production path the synthetic certificate
+suite cannot exercise. The fixture holds real third-party transaction data, so it
+is **gitignored and never committed**. When the file is absent (CI, fresh clone)
+the suite skips itself.
+
+## File
+
+`test/fixtures/real-apple-payloads.local.json`
+
+```json
+[
+  { "kind": "transaction", "jws": "eyJhbGciOiJFUzI1Ni…<full JWS>" },
+  { "kind": "receipt",     "jws": "eyJhbGciOiJFUzI1Ni…<full JWS>" }
+]
+```
+
+- `jws` — a complete compact JWS (`header.payload.signature`) whose `x5c` chain
+  terminates at Apple Root CA - G3.
+- `kind` — free-form label, used only in the test name.
+
+## How to (re)create it
+
+Any genuine Apple-signed JWS works. Easiest source you own:
+
+1. App Store Connect → your app → App Information → set the Sandbox server
+   notification URL, or use **Request a Test Notification** via the App Store
+   Server API. Capture the `signedPayload` your endpoint receives.
+2. Alternatively, capture a `signedTransactionInfo` / `signedRenewalInfo` from a
+   real or sandbox transaction.
+3. Drop the full JWS string(s) into the JSON file above.
+
+## Clock pinning
+
+The test pins the system clock (`vi.setSystemTime`) to **2026-01-01** so it stays
+deterministic regardless of run date. Apple leaf certificates are time-bounded; if
+your payload's leaf is valid outside that instant, adjust `PINNED` in
+`realPayloads.test.ts` to a date inside the leaf's `notBefore … notAfter` window
+(inspect with `openssl x509` on the first `x5c` entry).

--- a/test/realPayloads.test.ts
+++ b/test/realPayloads.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+import { verifySignedPayload } from '../src/jws/verifySignedPayload'
+
+/**
+ * Regression check against genuine Apple-signed payloads, verified through the
+ * default Apple Root CA - G3 fingerprint — the production path the synthetic
+ * suite cannot exercise.
+ *
+ * The fixture holds real third-party transaction data, so it is gitignored and
+ * never committed. When the file is absent (CI, fresh clone) the suite skips.
+ */
+const FIXTURE = fileURLToPath(new URL('./fixtures/real-apple-payloads.local.json', import.meta.url))
+
+interface RealPayload { kind: string, jws: string }
+
+const fixtures: RealPayload[] = existsSync(FIXTURE) ? JSON.parse(readFileSync(FIXTURE, 'utf8')) : []
+
+// The fixtures' leaf certificates are valid Sep 2025 – Oct 2027; pin the clock
+// inside that window so the test stays deterministic regardless of run date.
+const PINNED = new Date('2026-01-01T00:00:00Z')
+
+describe.skipIf(fixtures.length === 0)('real Apple payloads (local fixture)', () => {
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  it.each(fixtures)('verifies a real $kind payload against Apple Root CA - G3', async ({ jws }) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(PINNED)
+
+    const payload = await verifySignedPayload<{ bundleId: string }>(jws)
+
+    expect(payload.bundleId).toBeTruthy()
+  })
+})

--- a/test/realPayloads.test.ts
+++ b/test/realPayloads.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-import { afterAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { verifySignedPayload } from '../src/jws/verifySignedPayload'
 
@@ -15,7 +15,10 @@ import { verifySignedPayload } from '../src/jws/verifySignedPayload'
  */
 const FIXTURE = fileURLToPath(new URL('./fixtures/real-apple-payloads.local.json', import.meta.url))
 
-interface RealPayload { kind: string, jws: string }
+interface RealPayload {
+  kind: string
+  jws: string
+}
 
 const fixtures: RealPayload[] = existsSync(FIXTURE) ? JSON.parse(readFileSync(FIXTURE, 'utf8')) : []
 
@@ -24,14 +27,16 @@ const fixtures: RealPayload[] = existsSync(FIXTURE) ? JSON.parse(readFileSync(FI
 const PINNED = new Date('2026-01-01T00:00:00Z')
 
 describe.skipIf(fixtures.length === 0)('real Apple payloads (local fixture)', () => {
-  afterAll(() => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(PINNED)
+  })
+
+  afterEach(() => {
     vi.useRealTimers()
   })
 
   it.each(fixtures)('verifies a real $kind payload against Apple Root CA - G3', async ({ jws }) => {
-    vi.useFakeTimers()
-    vi.setSystemTime(PINNED)
-
     const payload = await verifySignedPayload<{ bundleId: string }>(jws)
 
     expect(payload.bundleId).toBeTruthy()


### PR DESCRIPTION
## Why

The certificate-chain suite (`verifySignedPayload.test.ts`, `decode.test.ts`) runs entirely on a **synthetic** chain — `createTestCertChain()` self-signs a root and verifies against its own fingerprint. The production path — verifying a genuine Apple-signed `signedPayload` against the pinned `APPLE_ROOT_CA` (Apple Root CA - G3) — had never been exercised on real data.

This adds a regression test that closes that gap, while keeping real third-party data out of the repository.

## What

- **`test/realPayloads.test.ts`** — verifies genuine Apple-signed payloads through the default `APPLE_ROOT_CA`. Confirmed three real payloads (two transactions + a receipt) verify cleanly; their chains terminate at `CN=Apple Root CA - G3` with the exact pinned fingerprint.
  - Skips itself (`describe.skipIf`) when the local fixture is absent, so CI and fresh clones are unaffected.
  - Pins the clock to `2026-01-01` (`vi.setSystemTime`) since Apple leaf certificates are time-bounded — the test stays deterministic regardless of run date.
- **`test/fixtures/README.md`** — documents the fixture format and how to (re)create it from your own sandbox payload ("Request a Test Notification"). Committed so the test is recoverable without the data.
- **`.gitignore`** — ignores `test/fixtures/*.local.json`. The real payloads contain third-party transaction identifiers and are never committed.

## Verification

- Full suite: 52 passed.
- With local fixture present: 3 real-payload tests pass.
- Without it: cleanly skipped.